### PR TITLE
Replace min/max macros with inline functions

### DIFF
--- a/emu2413.c
+++ b/emu2413.c
@@ -224,8 +224,13 @@ static int32_t rks_table[8 * 2][2];
 static OPLL_PATCH null_patch = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 static OPLL_PATCH default_patch[OPLL_TONE_NUM][(16 + 3) * 2];
 
-#define min(i, j) (((i) < (j)) ? (i) : (j))
-#define max(i, j) (((i) > (j)) ? (i) : (j))
+static INLINE int min(int i, int j) {
+  return (i < j) ? i : j;
+}
+
+static INLINE int max(int i, int j) {
+  return (i > j) ? i : j;
+}
 
 /***************************************************
 


### PR DESCRIPTION
This pull request fixes the warning below:
```
emu2413/emu2413.c:228:25: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
  228 | #define max(i, j) (((i) > (j)) ? (i) : (j))
      |                         ^
emu2413/emu2413.c:825:24: note: in expansion of macro 'max'
  825 |         slot->eg_out = max(0, ((int)slot->eg_out - (slot->eg_out >> s) - 1));
      |                        ^~~
```
This fixes a minor bug I experience in Phantasy Star for the Sega Master System after importing the code into my emulator.
I use musl libc and compile with:
```
-std=c99 -Wall -Wextra -Wshadow -Wmissing-prototypes -pedantic
```

References:
https://dustri.org/b/min-and-max-macro-considered-harmful.html
https://stackoverflow.com/questions/3437404/min-and-max-in-c