### PR TITLE
Use proper floating point division when setting rate conversion parameters

### DIFF
--- a/emu2413.c
+++ b/emu2413.c
@@ -1114,7 +1114,7 @@ void OPLL_delete(OPLL *opll) {
 
 static void reset_rate_conversion_params(OPLL *opll) {
   const double f_out = opll->rate;
-  const double f_inp = opll->clk / 72;
+  const double f_inp = opll->clk / 72.0;
 
   opll->out_time = 0;
   opll->out_step = ((uint32_t)f_inp) << 8;

--- a/emu2413.c
+++ b/emu2413.c
@@ -1416,14 +1416,14 @@ void OPLL_dumpToPatch(const uint8_t *dump, OPLL_PATCH *patch) {
 }
 
 void OPLL_getDefaultPatch(int32_t type, int32_t num, OPLL_PATCH *patch) {
-  OPLL_dump2patch(default_inst[type] + num * 8, patch);
+  OPLL_dumpToPatch(default_inst[type] + num * 8, patch);
 }
 
 void OPLL_setPatch(OPLL *opll, const uint8_t *dump) {
   OPLL_PATCH patch[2];
   int i;
   for (i = 0; i < 19; i++) {
-    OPLL_dump2patch(dump + i * 8, patch);
+    OPLL_dumpToPatchatch(dump + i * 8, patch);
     memcpy(&opll->patch[i * 2 + 0], &patch[0], sizeof(OPLL_PATCH));
     memcpy(&opll->patch[i * 2 + 1], &patch[1], sizeof(OPLL_PATCH));
   }


### PR DESCRIPTION
In reset_rate_conversion_params, a double is assigned from the result of the division of two integers, which is equivalent to using floor() on the value. This means this if statement is partially redundant:
```
if (floor(f_inp) != f_out && floor(f_inp + 0.5) != f_out)
```
If this is intentional, it should be noted in the header file that 49715 is the correct sample rate which disables internal resampling with a ~3.58MHz. I believe the more correct behaviour, however, would be to use a floating point value, as the example use case refers to a ~3.58MHz clock. In my own case, I use 3579545Hz (NTSC Sega Master System), which divided by 72 is 49715.902778, which is very close to 49716, and with floating point division I do not get the internal resampler when I use this value (as expected).