### PR TITLE
Fix clang 15 -pedantic warnings

### DIFF
--- a/emu2413.c
+++ b/emu2413.c
@@ -399,7 +399,7 @@ static void makeRksTable(void) {
     }
 }
 
-static void makeDefaultPatch() {
+static void makeDefaultPatch(void) {
   int i, j;
   for (i = 0; i < OPLL_TONE_NUM; i++)
     for (j = 0; j < 19; j++)
@@ -408,7 +408,7 @@ static void makeDefaultPatch() {
 
 static uint8_t table_initialized = 0;
 
-static void initializeTables() {
+static void initializeTables(void) {
   makeTllTable();
   makeRksTable();
   makeSinTable();


### PR DESCRIPTION
```
emu2413.c:402:29: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes] static void makeDefaultPatch() {
                            ^
                             void
emu2413.c:411:29: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes] static void initializeTables() {
                            ^
                             void
2 warnings generated.
```