### PR TITLE
Fix -Wcalloc-transposed-args

### DIFF
--- a/emu2413.c
+++ b/emu2413.c
@@ -1087,7 +1087,7 @@ OPLL *OPLL_new(uint32_t clk, uint32_t rate) {
     initializeTables();
   }
 
-  opll = (OPLL *)calloc(sizeof(OPLL), 1);
+  opll = (OPLL *)calloc(1, sizeof(OPLL));
   if (opll == NULL)
     return NULL;
 


### PR DESCRIPTION
Reference: https://linux.die.net/man/3/calloc

`void *calloc(size_t nmemb, size_t size);`

The calloc() function allocates memory for an array of nmemb elements of size bytes each and returns a pointer to the allocated memory. The memory is set to zero. If nmemb or size is 0, then calloc() returns either NULL, or a unique pointer value that can later be successfully passed to free(). 